### PR TITLE
dbeaver/pro#8222 Add provider properties to driver list command

### DIFF
--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/command/driver/ListDriversCommand.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/command/driver/ListDriversCommand.java
@@ -81,7 +81,9 @@ public class ListDriversCommand extends AbstractCommandLineParameterHandler {
                     for (DBPPropertyDescriptor prop : provider.getDriverProperties()) {
                         allProperties.put(prop.getId(), prop);
                     }
-
+                    for (DBPPropertyDescriptor prop : driver.getProviderPropertyDescriptors()) {
+                        allProperties.put(prop.getId(), prop);
+                    }
                     if (!allProperties.isEmpty()) {
                         outBuilder.append("    Properties:").append(System.lineSeparator());
                         for (DBPPropertyDescriptor prop : allProperties.values()) {

--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/command/driver/ListDriversCommand.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/command/driver/ListDriversCommand.java
@@ -78,9 +78,6 @@ public class ListDriversCommand extends AbstractCommandLineParameterHandler {
 
                 if (showProperties) {
                     Map<String, DBPPropertyDescriptor> allProperties = new LinkedHashMap<>();
-                    for (DBPPropertyDescriptor prop : provider.getDriverProperties()) {
-                        allProperties.put(prop.getId(), prop);
-                    }
                     for (DBPPropertyDescriptor prop : driver.getProviderPropertyDescriptors()) {
                         allProperties.put(prop.getId(), prop);
                     }


### PR DESCRIPTION
Cassandra has a pro driver there are properties like 
```
Provider: Cassandra (cassandra)
  Driver ID: cql, Status: Enabled, Description: Driver for Apache Cassandra 2.x/3.x/4.x
    Properties:
      - @dbeaver-cas.net.datacenter@ (Datacenter) = Datacenter used to establish the driver connection
      - @dbeaver-default.consistency.level@ (Default consistency level) = Default consistency level for queries, possible values: ANY, ONE, TWO, THREE, QUORUM, ALL, LOCAL_QUORUM, EACH_QUORUM, SERIAL, LOCAL_SERIAL, LOCAL_ONE
      - @dbeaver-enable.query.trace@ (Enable query tracing) = Enable CQL queries trace (available in results Trace panel)
      - @dbeaver-cas.timeout.connect@ (Connect timeout (ms)) = Defines how long the driver waits to establish a new connection to a Cassandra node before giving up.
      - @dbeaver-cas.timeout.read@ (Read timeout (ms)) = Defines how long the driver will wait for a given Cassandra node to answer a query.
```