### PR TITLE
dbeaver/pro#8509 Remove dots from dbvr help desctiptions

### DIFF
--- a/bundles/org.dbvr.cli.sql/src/org/dbvr/cli/sql/DataTransferOptions.java
+++ b/bundles/org.dbvr.cli.sql/src/org/dbvr/cli/sql/DataTransferOptions.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2025 DBeaver Corp and others
+ * Copyright (C) 2010-2026 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class DataTransferOptions {
     @Nullable
     @CommandLine.Option(names = {"-op", "--output-format-parameters"},
         arity = "1",
-        description = "Parameters (exporter options as list of props prop1=value1,prop2=value2 coma and space are delimiters).")
+        description = "Parameters (exporter options as list of props prop1=value1,prop2=value2 coma and space are delimiters)")
     private String outputFormatParameters;
 
 

--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/command/datasource/UpdateDataSource.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/command/datasource/UpdateDataSource.java
@@ -43,7 +43,7 @@ public class UpdateDataSource extends AbstractDataSourceCommand {
     @CommandLine.Option(
         names = {"-net-delete", "--network-handler-delete"},
         arity = "1",
-        description = "Network handler id for deletion."
+        description = "Network handler id for deletion"
     )
     private List<String> handlersToDelete;
 


### PR DESCRIPTION
Also removed`.` from the network-handlers command
<img width="656" height="351" alt="image" src="https://github.com/user-attachments/assets/55b1271a-d600-433a-ae01-f616c16d31ce" />
