### PR TITLE
dbeaver/pro#8417 Add support for short IDs in data export processors

### DIFF
--- a/bundles/org.dbvr.cli.sql/src/org/dbvr/cli/sql/SQLCommand.java
+++ b/bundles/org.dbvr.cli.sql/src/org/dbvr/cli/sql/SQLCommand.java
@@ -170,7 +170,7 @@ public class SQLCommand extends CommandLineWithAuth {
         DataTransferProcessorDescriptor processorDescriptor = DataTransferRegistry.getInstance()
             .getAvailableProcessors(StreamTransferConsumer.class, DBSEntity.class)
             .stream()
-            .filter(p -> p.getProcessorFileExtension().equals(outputFormat))
+            .filter(p -> outputFormat.equals(p.getShortId()) || outputFormat.equals(p.getProcessorFileExtension()))
             .findFirst()
             .orElse(null);
         if (processorDescriptor == null) {

--- a/bundles/org.dbvr.cli.sql/src/org/dbvr/cli/sql/SQLCommand.java
+++ b/bundles/org.dbvr.cli.sql/src/org/dbvr/cli/sql/SQLCommand.java
@@ -170,9 +170,14 @@ public class SQLCommand extends CommandLineWithAuth {
         DataTransferProcessorDescriptor processorDescriptor = DataTransferRegistry.getInstance()
             .getAvailableProcessors(StreamTransferConsumer.class, DBSEntity.class)
             .stream()
-            .filter(p -> outputFormat.equals(p.getShortId()) || outputFormat.equals(p.getProcessorFileExtension()))
+            .filter(p -> outputFormat.equals(p.getShortId()))
             .findFirst()
-            .orElse(null);
+            .orElseGet(() -> DataTransferRegistry.getInstance()
+                .getAvailableProcessors(StreamTransferConsumer.class, DBSEntity.class)
+                .stream()
+                .filter(p -> outputFormat.equals(p.getProcessorFileExtension()))
+                .findFirst()
+                .orElse(null));
         if (processorDescriptor == null) {
             throw new CLIException(
                 "Can't find data transfer processor for format '" + outputFormat + "'",


### PR DESCRIPTION
```
sql
-con="driver=sqlite_ee|url=jdbc:sqlite:/Users/labanovichttps/Library/DBeaverData/workspace6/.metadata/sample-database-sqlite-1/Chinook.db"
-format=md
"select count(*) from Artist;"
```
now we could also use user friendly formatters:
| shortId | id | 
| xml | stream.xml |
| dbunit | stream.dbunit |
| json | stream.json | 
| html | stream.html | 
| csv | stream.csv | 
| markdown | stream.markdown.table | 
| sql | stream.sql | 
| txt | stream.txt |