### PR TITLE
dbeaver/dbvr#103 Add lowercase -v alias for version option

### DIFF
--- a/bundles/org.dbvr.cli/plugin.xml
+++ b/bundles/org.dbvr.cli/plugin.xml
@@ -11,7 +11,9 @@
         <parameter
             exitAfterExecute="true"
             handler="org.dbvr.cli.command.project.ProjectManagementCommand"/>
-        <transformer transformer="org.dbvr.cli.app.VersionAliasTransformer"/>
+        <transformer
+            command="org.dbvr.cli.app.CLITopLevelCommand"
+            transformer="org.dbvr.cli.app.VersionAliasTransformer"/>
     </extension>
 
     <extension point="org.jkiss.dbeaver.service">

--- a/bundles/org.dbvr.cli/plugin.xml
+++ b/bundles/org.dbvr.cli/plugin.xml
@@ -11,6 +11,7 @@
         <parameter
             exitAfterExecute="true"
             handler="org.dbvr.cli.command.project.ProjectManagementCommand"/>
+        <transformer transformer="org.dbvr.cli.app.VersionAliasTransformer"/>
     </extension>
 
     <extension point="org.jkiss.dbeaver.service">

--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/app/CLITopLevelCommand.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/app/CLITopLevelCommand.java
@@ -45,14 +45,6 @@ public class CLITopLevelCommand extends AbstractTopLevelCommand {
     )
     private boolean stateless;
 
-    @CommandLine.Option(
-        names = {"-v"},
-        hidden = true,
-        versionHelp = true,
-        scope = CommandLine.ScopeType.INHERIT
-    )
-    private boolean versionAlias;
-
     protected CLITopLevelCommand(
         @Nullable ApplicationInstanceController controller,
         @NotNull CLIContextImpl context,

--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/app/CLITopLevelCommand.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/app/CLITopLevelCommand.java
@@ -45,6 +45,14 @@ public class CLITopLevelCommand extends AbstractTopLevelCommand {
     )
     private boolean stateless;
 
+    @CommandLine.Option(
+        names = {"-v"},
+        hidden = true,
+        versionHelp = true,
+        scope = CommandLine.ScopeType.INHERIT
+    )
+    private boolean versionAlias;
+
     protected CLITopLevelCommand(
         @Nullable ApplicationInstanceController controller,
         @NotNull CLIContextImpl context,

--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/app/VersionAliasTransformer.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/app/VersionAliasTransformer.java
@@ -23,10 +23,6 @@ import picocli.CommandLine.Model.OptionSpec;
 
 import java.util.Arrays;
 
-/**
- * Adds a lowercase {@code -v} alias to the existing {@code -V}/{@code --version} option
- * instead of declaring a competing {@code versionHelp} option.
- */
 public class VersionAliasTransformer implements CommandLine.IModelTransformer {
     private static final String VERSION_ALIAS = "-v";
 
@@ -40,19 +36,7 @@ public class VersionAliasTransformer implements CommandLine.IModelTransformer {
         String[] names = Arrays.copyOf(versionOption.names(), versionOption.names().length + 1);
         names[names.length - 1] = VERSION_ALIAS;
         commandSpec.remove(versionOption);
-        removeStaleVersionCopies(commandSpec);
         commandSpec.addOption(OptionSpec.builder(versionOption).names(names).build());
         return commandSpec;
-    }
-
-    private void removeStaleVersionCopies(@NotNull CommandSpec commandSpec) {
-        for (CommandLine subcommand : commandSpec.subcommands().values()) {
-            CommandSpec subSpec = subcommand.getCommandSpec();
-            OptionSpec staleCopy = subSpec.findOption("--version");
-            if (staleCopy != null) {
-                subSpec.remove(staleCopy);
-            }
-            removeStaleVersionCopies(subSpec);
-        }
     }
 }

--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/app/VersionAliasTransformer.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/app/VersionAliasTransformer.java
@@ -1,0 +1,62 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dbvr.cli.app;
+
+import org.jkiss.code.NotNull;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.OptionSpec;
+
+import java.util.Arrays;
+
+/**
+ * Adds a lowercase {@code -v} alias to the existing {@code -V}/{@code --version} option
+ * instead of declaring a competing {@code versionHelp} option.
+ */
+public class VersionAliasTransformer implements CommandLine.IModelTransformer {
+    private static final String VERSION_ALIAS = "-v";
+
+    @NotNull
+    @Override
+    public CommandSpec transform(@NotNull CommandSpec commandSpec) {
+        OptionSpec versionOption = commandSpec.findOption("--version");
+        if (versionOption == null || Arrays.asList(versionOption.names()).contains(VERSION_ALIAS)) {
+            return commandSpec;
+        }
+        String[] names = Arrays.copyOf(versionOption.names(), versionOption.names().length + 1);
+        names[names.length - 1] = VERSION_ALIAS;
+        commandSpec.remove(versionOption);
+        // Subcommands (at every depth) added before this transformer runs already hold their own
+        // inherited copy of versionOption (picocli pushes INHERIT-scoped options down the whole
+        // subcommand tree on addSubcommand()). Remove those stale copies too, otherwise addOption()
+        // below fails when it re-cascades the replacement option through the same tree.
+        removeStaleVersionCopies(commandSpec);
+        commandSpec.addOption(OptionSpec.builder(versionOption).names(names).build());
+        return commandSpec;
+    }
+
+    private void removeStaleVersionCopies(@NotNull CommandSpec commandSpec) {
+        for (CommandLine subcommand : commandSpec.subcommands().values()) {
+            CommandSpec subSpec = subcommand.getCommandSpec();
+            OptionSpec staleCopy = subSpec.findOption("--version");
+            if (staleCopy != null) {
+                subSpec.remove(staleCopy);
+            }
+            removeStaleVersionCopies(subSpec);
+        }
+    }
+}

--- a/bundles/org.dbvr.cli/src/org/dbvr/cli/app/VersionAliasTransformer.java
+++ b/bundles/org.dbvr.cli/src/org/dbvr/cli/app/VersionAliasTransformer.java
@@ -40,10 +40,6 @@ public class VersionAliasTransformer implements CommandLine.IModelTransformer {
         String[] names = Arrays.copyOf(versionOption.names(), versionOption.names().length + 1);
         names[names.length - 1] = VERSION_ALIAS;
         commandSpec.remove(versionOption);
-        // Subcommands (at every depth) added before this transformer runs already hold their own
-        // inherited copy of versionOption (picocli pushes INHERIT-scoped options down the whole
-        // subcommand tree on addSubcommand()). Remove those stale copies too, otherwise addOption()
-        // below fails when it re-cascades the replacement option through the same tree.
         removeStaleVersionCopies(commandSpec);
         commandSpec.addOption(OptionSpec.builder(versionOption).names(names).build());
         return commandSpec;

--- a/test/org.dbvr.test.platform/src/org/dbvr/test/DBVRTestSuite.java
+++ b/test/org.dbvr.test.platform/src/org/dbvr/test/DBVRTestSuite.java
@@ -27,6 +27,7 @@ import org.junit.platform.suite.api.Suite;
 @Suite
 @SelectClasses({
     HelpArgTest.class,
+    VersionArgTest.class,
     DataSourceManagementTest.class,
     ProjectManagementTest.class,
     AuthModelsTest.class,

--- a/test/org.dbvr.test.platform/src/org/dbvr/test/VersionArgTest.java
+++ b/test/org.dbvr.test.platform/src/org/dbvr/test/VersionArgTest.java
@@ -1,0 +1,44 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2026 DBeaver Corp and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dbvr.test;
+
+import org.jkiss.dbeaver.model.cli.CLIProcessResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VersionArgTest extends DBVRTest {
+
+    @Test
+    public void testLowercaseVersionOptionPrintsVersion() throws Exception {
+        String[] args = {"-v"};
+        CLIProcessResult result = DBVRTestSuite.getApplication().executeCommandLine(args);
+
+        String[] canonicalArgs = {"--version"};
+        CLIProcessResult canonicalResult = DBVRTestSuite.getApplication().executeCommandLine(canonicalArgs);
+
+        Assertions.assertEquals(CLIProcessResult.PostAction.SHUTDOWN, result.getPostAction());
+        Assertions.assertEquals(canonicalResult.getOutput(), result.getOutput());
+    }
+
+    @Test
+    public void testUnknownShortOptionIsRejected() throws Exception {
+        String[] args = {"-x"};
+        CLIProcessResult result = DBVRTestSuite.getApplication().executeCommandLine(args);
+
+        Assertions.assertEquals(CLIProcessResult.PostAction.ERROR, result.getPostAction());
+    }
+}


### PR DESCRIPTION
`closes #103`

Add `-v` as a lowercase alias for `-V`/`--version`:

```
dbvr -v
dbvr 26.1.4
```
Implemented as a `CommandLine.IModelTransformer` (registered via the `commandLine` extension point) that extends the existing `--version` option's names instead of declaring a second competing option — avoids a picocli warning and keeps `-v` consistent across all subcommands.