### PR TITLE
dbeaver/pro#10477 Optimize bundle dependencies

### DIFF
--- a/bundles/org.dbvr.cli.sql/META-INF/MANIFEST.MF
+++ b/bundles/org.dbvr.cli.sql/META-INF/MANIFEST.MF
@@ -8,8 +8,6 @@ Bundle-Release-Date: 20260921
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.dbvr.cli.sql
-Require-Bundle: org.jkiss.dbeaver.model.sql,
- org.jkiss.dbeaver.data.transfer,
- org.jkiss.dbeaver.registry,
- org.dbvr.cli
+Require-Bundle: org.jkiss.dbeaver.data.transfer,
+ org.dbvr.cli;visibility:=reexport
 Automatic-Module-Name: org.dbvr.cli.sql

--- a/bundles/org.dbvr.cli/META-INF/MANIFEST.MF
+++ b/bundles/org.dbvr.cli/META-INF/MANIFEST.MF
@@ -8,9 +8,8 @@ Bundle-Release-Date: 20260921
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.dbvr.cli.app.CLIActivator
 Bundle-RequiredExecutionEnvironment: JavaSE-21
-Require-Bundle: org.jkiss.dbeaver.model;visibility:=reexport,
- org.jkiss.dbeaver.model.cli;visibility:=reexport,
- org.jkiss.dbeaver.registry
+Require-Bundle: org.jkiss.dbeaver.model.cli;visibility:=reexport,
+ org.jkiss.dbeaver.registry;visibility:=reexport
 Export-Package: org.dbvr.cli.app,
  org.dbvr.cli.command.datasource
 Automatic-Module-Name: org.dbvr.app.ce

--- a/test/org.dbvr.test.platform/META-INF/MANIFEST.MF
+++ b/test/org.dbvr.test.platform/META-INF/MANIFEST.MF
@@ -9,12 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.dbvr.app.ce,
  org.dbvr.app.ce.test,
- org.jkiss.dbeaver.model.sql,
- org.jkiss.dbeaver.data.transfer,
- org.jkiss.dbeaver.registry,
  org.jkiss.dbeaver.osgi.test.runner;visibility:=reexport,
- org.dbvr.cli;visibility:=reexport,
  org.jkiss.dbeaver.net.ssh,
  org.jkiss.dbeaver.ext.h2,
- org.dbvr.cli.sql,
- org.jkiss.dbeaver.model.cli
+ org.dbvr.cli.sql


### PR DESCRIPTION
Closes dbeaver/pro#10477

## Summary
- remove unused and transitively redundant OSGi bundle requirements
- re-export dependencies exposed through bundle APIs

## Testing
- `mvn package -f product/aggregate/pom.xml -Dheadless-platform -T1C -Pproduct-dbvr-ce`
- `git diff --check`

This PR was generated with AI assistance.