### PR TITLE
dbeaver/pro#10479 Reuse application launch parameters

### DIFF
--- a/product/community-unittest/dbvr-unittest.product
+++ b/product/community-unittest/dbvr-unittest.product
@@ -13,35 +13,7 @@
         <programArgsMac>-vm ../Eclipse/jre/Contents/Home/lib/libjli.dylib</programArgsMac>
 
         <vmArgs>
-            -XX:+IgnoreUnrecognizedVMOptions
-            -Dosgi.requiredJavaVersion=21
-            -Dfile.encoding=UTF-8
-            -Ddbeaver.disable.remote.cli.execution=true
-            --enable-native-access=ALL-UNNAMED
-            --add-modules=ALL-DEFAULT
-            --add-opens=java.base/java.io=ALL-UNNAMED
-            --add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
-            --add-opens=java.base/java.net=ALL-UNNAMED
-            --add-opens=java.base/java.nio=ALL-UNNAMED
-            --add-opens=java.base/java.nio.charset=ALL-UNNAMED
-            --add-opens=java.base/java.text=ALL-UNNAMED
-            --add-opens=java.base/java.time=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
-            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-            --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
-            --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
-            --add-opens=java.base/sun.security.util=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.jgss=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.desktop/java.awt=ALL-UNNAMED
-            --add-opens=java.desktop/java.awt.peer=ALL-UNNAMED
-            --add-opens=java.sql/java.sql=ALL-UNNAMED
+            <!-- dbeaver-launch-parameters: cli,common -->
             -Xms64m
             -Xmx1024m</vmArgs>
         <vmArgsMac>-XstartOnFirstThread</vmArgsMac>

--- a/product/community/dbvr.product
+++ b/product/community/dbvr.product
@@ -13,35 +13,7 @@
         <programArgsMac>-vm ../Eclipse/jre/Contents/Home/lib/libjli.dylib</programArgsMac>
 
         <vmArgs>
-            -XX:+IgnoreUnrecognizedVMOptions
-            -Dosgi.requiredJavaVersion=21
-            -Dfile.encoding=UTF-8
-            -Ddbeaver.disable.remote.cli.execution=true
-            --enable-native-access=ALL-UNNAMED
-            --add-modules=ALL-DEFAULT
-            --add-opens=java.base/java.io=ALL-UNNAMED
-            --add-opens=java.base/java.lang=ALL-UNNAMED
-            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
-            --add-opens=java.base/java.net=ALL-UNNAMED
-            --add-opens=java.base/java.nio=ALL-UNNAMED
-            --add-opens=java.base/java.nio.charset=ALL-UNNAMED
-            --add-opens=java.base/java.text=ALL-UNNAMED
-            --add-opens=java.base/java.time=ALL-UNNAMED
-            --add-opens=java.base/java.util=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED
-            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
-            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-            --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
-            --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
-            --add-opens=java.base/sun.security.util=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.jgss=ALL-UNNAMED
-            --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED
-            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-            --add-opens=java.desktop/java.awt=ALL-UNNAMED
-            --add-opens=java.desktop/java.awt.peer=ALL-UNNAMED
-            --add-opens=java.sql/java.sql=ALL-UNNAMED
+            <!-- dbeaver-launch-parameters: cli,common -->
             -Xms64m
             -Xmx1024m</vmArgs>
         <vmArgsMac>-XstartOnFirstThread</vmArgsMac>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -12,6 +12,23 @@
     <artifactId>product</artifactId>
     <packaging>pom</packaging>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jkiss.dbeaver</groupId>
+                <artifactId>product-generator</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-p2-publisher-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <productsDirectory>${project.build.directory}/generated-products</productsDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>product-dbvr-ce</id>


### PR DESCRIPTION
Closes dbeaver/pro#10479

Depends on dbeaver/dbeaver#41977.

## Summary
- replace duplicated dbvr launch parameters with named CLI and common sets
- generate product descriptors before Tycho publication
- preserve dbvr-specific program, heap, and macOS arguments

## Testing
- generated the dbvr product descriptor with the product generator

This PR was generated with AI (OpenCode).